### PR TITLE
Create layout.conf (#1)

### DIFF
--- a/app-office/wordgrinder/wordgrinder-0.3.3-p1.ebuild
+++ b/app-office/wordgrinder/wordgrinder-0.3.3-p1.ebuild
@@ -13,7 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
 
-RDEPEND="dev-libs/luafilesystem
+RDEPEND="dev-lua/luafilesystem
 	sys-libs/ncurses"
 DEPEND="${RDEPEND}"
 

--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo


### PR DESCRIPTION
Address portage warning:
!!! Repository 'overnight' is missing masters attribute in '/var/lib/layman/overnight/metadata/layout.conf'
!!! Set 'masters = gentoo' in this file for future compatibility
